### PR TITLE
Update Predictor wrapper for new sam-2 API

### DIFF
--- a/cataractsam2/predictor.py
+++ b/cataractsam2/predictor.py
@@ -13,8 +13,11 @@ class Predictor:
     """
     # ----------------------------------------------------
     def __init__(self, weights: str | Path, device: str = "cuda"):
+        # Upstream ``build_sam2_video_predictor`` now expects ``config_file``
+        # instead of ``model_cfg``. Match the new signature so the wrapper
+        # remains compatible with the latest ``sam-2`` package.
         self.pred = build_sam2_video_predictor(
-            model_cfg=str(CFG),
+            config_file=str(CFG),
             ckpt=str(weights),
             device=device,
         )


### PR DESCRIPTION
## Summary
- update `Predictor` to pass `config_file=` when building the SAM‑2 video predictor

## Testing
- `python -m compileall -q cataractsam2`

------
https://chatgpt.com/codex/tasks/task_e_6869600f6a34832991ae80074f26f6b5