### PR TITLE
Fix Predictor API and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ setup(pred, "data/frames")
 Object(0, 1)  # start annotating object 1 on frame 0
 ```
 
+`Predictor` passes Hydra the bundled configuration
+`cataractsam2/cfg/sam2_hiera_l.yaml`.  If you need to override this file,
+specify `config_file=PATH` when instantiating the class.
+
 Click positive/negative points or draw bounding boxes to guide the model.
 You can visualise intermediate masks with:
 
@@ -61,6 +65,12 @@ Finally export masks for all frames and objects:
 from cataractsam2 import Masks
 Masks("./masks")  # one PNG per frame/object
 ```
+
+**Workflow summary:** clone the repository, run `pip install -e .`, download
+`Cataract-SAM2.pth` with the helper script, then open a Python session and
+create a `Predictor` with your checkpoint.  Initialise the widget on your
+frame directory, refine masks interactively and propagate them through the
+video, finally exporting the results with `Masks("./masks")`.
 
 ## Project structure
 

--- a/cataractsam2/predictor.py
+++ b/cataractsam2/predictor.py
@@ -12,12 +12,15 @@ class Predictor:
     >>> state = pred.init_state(video_path="data/frames")
     """
     # ----------------------------------------------------
-    def __init__(self, weights: str | Path, device: str = "cuda"):
-        # Upstream ``build_sam2_video_predictor`` now expects ``config_file``
-        # instead of ``model_cfg``. Match the new signature so the wrapper
-        # remains compatible with the latest ``sam-2`` package.
+    def __init__(
+        self,
+        weights: str | Path,
+        config_file: str | Path = CFG,
+        device: str = "cuda",
+    ):
+        """Wrap ``build_sam2_video_predictor`` with sane defaults."""
         self.pred = build_sam2_video_predictor(
-            config_file=str(CFG),
+            config_file=str(Path(config_file)),
             ckpt=str(weights),
             device=device,
         )


### PR DESCRIPTION
## Summary
- expose `config_file` argument in `Predictor` to align with `sam-2`
- clarify that the default YAML is bundled with the package
- document the full workflow to install the repo and run the widget

## Testing
- `python -m py_compile cataractsam2/predictor.py`


------
https://chatgpt.com/codex/tasks/task_e_686967f55f7083298fdf87b130621a7a