### PR TITLE
Fix package exports and update quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Place your video frames as numbered JPEG files under a directory
 (e.g. `data/frames/000.jpg`, `001.jpg`, …).  Then launch a Python session:
 
 ```python
-from cataractsam2 import Predictor
-from cataractsam2.ui_widget import setup, Object
+from cataractsam2 import Predictor, setup, Object
 
 pred = Predictor("checkpoints/Cataract-SAM2.pth")
 setup(pred, "data/frames")

--- a/cataractsam2/__init__.py
+++ b/cataractsam2/__init__.py
@@ -1,8 +1,9 @@
-from .ui_widget import Object, Reset, Visualize, Propagate, video_segments
+from .ui_widget import Object, Reset, Visualize, Propagate, setup, video_segments
 from .masks     import Masks
 from .predictor import Predictor
 
 __all__ = [
+    "setup",
     "Object", "Reset", "Visualize", "Propagate",
     "Masks",
     "Predictor",


### PR DESCRIPTION
## Summary
- export `setup` from `cataractsam2` so it can be imported from the package root
- update README quick‑start code block to use the new import

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686974a64b8083298e0ee773241f460b