### PR TITLE
Use file URI for default config

### DIFF
--- a/cataractsam2/predictor.py
+++ b/cataractsam2/predictor.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from sam2.build_sam import build_sam2_video_predictor
 
-# Default configuration packaged with the library.  Using the ``pkg://``
-# scheme makes Hydra load the YAML from this installed module.
-CFG   = "pkg://cataractsam2/cfg/sam2_hiera_l.yaml"
+# Default configuration packaged with the library.  Convert the path to a
+# ``file://`` URI so Hydra can load it directly without relying on the search
+# path plugin.
+CFG_PATH = Path(__file__).parent / "cfg" / "sam2_hiera_l.yaml"
+CFG = CFG_PATH.resolve().as_uri()
 
 class Predictor:
     """


### PR DESCRIPTION
## Summary
- load default `sam2_hiera_l.yaml` using an absolute file URI instead of `pkg://`

## Testing
- `pip install ipywidgets numpy`
- `pip install 'sam-2 @ git+https://github.com/facebookresearch/segment-anything-2@main'` *(fails: Package not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf732054883299ee8af206e914e53