### PR TITLE
Parse requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 from setuptools import setup, find_packages
 
+
+def _read_requirements():
+    """Read requirements.txt, ignoring editable installs."""
+    with open("requirements.txt") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("-e") and not line.startswith("--editable"):
+                yield line
+
 setup(
     name="cataractsam2",
     version="0.1.0",
@@ -7,7 +16,7 @@ setup(
     include_package_data=True,      # ships YAML inside cfg/
     package_data={"cataractsam2": ["cfg/*.yaml"]},
     python_requires=">=3.10",
-    install_requires=[l.strip() for l in open("requirements.txt") if l.strip()],
+    install_requires=list(_read_requirements()),
     entry_points={
     "hydra.searchpath": [
       # point to the module path and class name you just created


### PR DESCRIPTION
## Summary
- parse `requirements.txt` in `setup.py`
- ignore `-e`/`--editable` lines

## Testing
- `python -m py_compile setup.py`
- `python -m pip install -e .` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_686c32b5cfc883298d29595b01b844a3